### PR TITLE
修复了2.3版本使用OSS上传方案无法上传的问题.

### DIFF
--- a/includes/adminAction.php
+++ b/includes/adminAction.php
@@ -45,7 +45,7 @@ switch ($action) {
 		$policyname=$_POST['policyname'];
 		$policytype=$_POST['policytype'];
 		$kjm=$_POST['kjm'];
-		$p_server=$_POST['p_server'];
+		$p_server="http://".$_POST['p_server']."/";
 		$p_dir=$_POST['p_dir'];
 		$namerule=$_POST['namerule'];
 		$zzurl=$_POST['zzurl'];


### PR DESCRIPTION
由于后台添加上传策略时，特别提示用户无需添加“http://”和URL结尾的“/”，从而出现逻辑错误，OSS上传出现404问题。
Example：
/admin/add_policy.php
设置OSS外网域名:cyttest.oss-cn-hangzhou.aliyuncs.com
终端提示`plupload.full.min.js:6995 POST http://shudong//cyttest.oss-cn-hangzhou.aliyuncs.com 404 (Not Found)`
修复后：
/admin/add_policy.php
设置OSS外网域名:cyttest.oss-cn-hangzhou.aliyuncs.com
成功上传
